### PR TITLE
🐛Allow service to test Vault

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -13,6 +13,11 @@ var vaultRoleID, vaultSecretID, noKVRoleID, noKVSecretID string
 
 var vaultVersion string
 
+var _ = func() bool {
+	testing.Init()
+	return true
+}()
+
 func init() {
 	flag.StringVar(&vaultVersion, "vaultVersion", "1.0.1", "provide vault version to be tested against")
 	flag.Parse()

--- a/test-files/initVaultDev.sh
+++ b/test-files/initVaultDev.sh
@@ -3,11 +3,23 @@ export VAULT_ADDR=http://localhost:8200
 export VAULT_TOKEN=my-dev-root-vault-token
 export VAULT_VERSION=${1:-1.0.1}
 
+case "$(uname -s)" in
+  Darwin*)
+    os="darwin_amd64"
+    ;;
+  MINGW64*)
+    os="windows_amd64"
+    ;;
+  *)
+    os="linux_amd64"
+    ;;
+esac
+
 CURRENT_VAULT=`./vault version | cut -d'v' -f2 | cut -d' ' -f1`
 if [ "$CURRENT_VAULT" != "$VAULT_VERSION" ]; then
     rm -rf ./vault
-    curl -kO https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip
-    unzip vault_${VAULT_VERSION}_linux_amd64.zip
+    curl -kO https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_${os}.zip
+    unzip vault_${VAULT_VERSION}_${os}.zip
 fi
 
 ./vault server -dev -dev-root-token-id ${VAULT_TOKEN}  > /tmp/vaultdev.log &


### PR DESCRIPTION
## Context and Description of Changes Proposed

Tests on the base vaultlib library fail with:
```error getting role id fork/exec ./vault: exec format error []```
Also, under some versions of go (including 1.13), tests fail with:
```provide vault version to be tested against (default "1.0.1")```
due to differences in init function execution order between versions of go.

This PR comprises Atha's solution to the first problem (commit "Atha's fix - get correct vault for localhost OS") and Deric's solution to the second ("Force correct ordering of init()s for go versions"), which in combination should fix the testing issues with the base library.  Reviewers should run ```go test``` in /vaultlib to confirm.

## Draft Commit Message Body

Update vaultlib to pass tests under current golang versions and across
operating systems.

PR #8
close [ch1055]